### PR TITLE
Cache Rails Gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3-alpine3.8
+FROM ruby:alpine3.11
 LABEL maintainer="juandedioz@gmail.com"
 
 # Minimal requirements to run a Rails app
@@ -23,3 +23,5 @@ RUN bundle install
 # Copy the application into the container
 COPY . APP_PATH
 EXPOSE 3000
+
+CMD ["puma", "-C", "config/puma.rb"]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,28 @@ Visit your application
 http://localhost:3000
 ```
 
+### Gems installation
+A dedicated volume which only holds the gems have been implemented in `docker-compose.yml`
+Instead of building the container every time you add/remove a gem which install a fresh all the gems, you can reuse the stored ones.This helps speeding up development since rebuilding is time consuming.
+
+To install the gems in the cache volume.
+```
+docker-compose run web bundle install
+```
+When you add/remove a gem, bring down the containers first
+```
+docker-compose down
+```
+Then install
+```
+docker-compose run web bundle install
+```
+And bring the containers up
+```
+docker-compose up
+```
+
 ### Troubleshooting
 
-1. If you have probles with `pg` gem you should install Postgres before. On Mac `brew install postgres`
+1. If you have problems with `pg` gem you should install Postgres before. On Mac `brew install postgres`
 2. Ruby Version `2.5.3`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,16 @@ services:
     image: postgres:11.1-alpine
   web:
     build: .
-    command: bin/rails s -p 3000 -b '0.0.0.0'
+    command: 'puma -C config/puma.rb'
     volumes:
       - .:/usr/src/app
+      - bundle_path:/bundle
+    environment:
+      - BUNDLE_PATH=/bundle/vendor
     ports:
       - "3000:3000"
     depends_on:
       - db
+
+volumes:
+  bundle_path: 


### PR DESCRIPTION
- Cache rails gems in a volume for reuse
- The base image you have supports nodejs < 8.16 , Web packer requires greater than that.
- The base image will also use ruby 2.7.0
- The run commad `CMD` will support `docker-compose run web rails db:migrate` like of commands.